### PR TITLE
update outdated versions which gave warnings in Node14

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/Lostmyname/heroku-buildpack-upload-static-assets-to-s3#readme",
   "dependencies": {
-    "async": "^2.0.1",
+    "async": "^3.2.0",
     "aws-sdk": "^2.5.0",
     "glob": "^7.0.5",
     "lodash": "^4.15.0",
     "mime-types": "^2.1.11",
-    "shelljs": "^0.7.3"
+    "shelljs": "^0.8.4"
   }
 }


### PR DESCRIPTION
I made a fork to fix the warnings in Node 14 caused by an old version of ShellJs.